### PR TITLE
revert changes and bump version to 0.10.0.3

### DIFF
--- a/docker/hoodie/hadoop/base/pom.xml
+++ b/docker/hoodie/hadoop/base/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/datanode/pom.xml
+++ b/docker/hoodie/hadoop/datanode/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/historyserver/pom.xml
+++ b/docker/hoodie/hadoop/historyserver/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/hive_base/pom.xml
+++ b/docker/hoodie/hadoop/hive_base/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/namenode/pom.xml
+++ b/docker/hoodie/hadoop/namenode/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/pom.xml
+++ b/docker/hoodie/hadoop/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/docker/hoodie/hadoop/prestobase/pom.xml
+++ b/docker/hoodie/hadoop/prestobase/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/spark_base/pom.xml
+++ b/docker/hoodie/hadoop/spark_base/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/sparkadhoc/pom.xml
+++ b/docker/hoodie/hadoop/sparkadhoc/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/sparkmaster/pom.xml
+++ b/docker/hoodie/hadoop/sparkmaster/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/docker/hoodie/hadoop/sparkworker/pom.xml
+++ b/docker/hoodie/hadoop/sparkworker/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi-hadoop-docker</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/hudi-aws/pom.xml
+++ b/hudi-aws/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <artifactId>hudi</artifactId>
         <groupId>io.hops.hudi</groupId>
-        <version>0.10.0.1</version>
+        <version>0.10.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hudi-aws</artifactId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
 
     <name>hudi-aws</name>
     <packaging>jar</packaging>

--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-client/hudi-client-common/pom.xml
+++ b/hudi-client/hudi-client-common/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <artifactId>hudi-client</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-client-common</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
   <name>hudi-client-common</name>
   <packaging>jar</packaging>
 

--- a/hudi-client/hudi-flink-client/pom.xml
+++ b/hudi-client/hudi-flink-client/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <artifactId>hudi-client</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-flink-client</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-flink-client</name>
   <packaging>jar</packaging>

--- a/hudi-client/hudi-java-client/pom.xml
+++ b/hudi-client/hudi-java-client/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <artifactId>hudi-client</artifactId>
         <groupId>io.hops.hudi</groupId>
-        <version>0.10.0.1</version>
+        <version>0.10.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hudi-java-client</artifactId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
 
     <name>hudi-java-client</name>
     <packaging>jar</packaging>

--- a/hudi-client/hudi-spark-client/pom.xml
+++ b/hudi-client/hudi-spark-client/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <artifactId>hudi-client</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-spark-client</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-spark-client</name>
   <packaging>jar</packaging>

--- a/hudi-client/pom.xml
+++ b/hudi-client/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-examples/pom.xml
+++ b/hudi-examples/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-flink/pom.xml
+++ b/hudi-flink/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-hadoop-mr/pom.xml
+++ b/hudi-hadoop-mr/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-integ-test/pom.xml
+++ b/hudi-integ-test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>hudi-integ-test</artifactId>

--- a/hudi-kafka-connect/pom.xml
+++ b/hudi-kafka-connect/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <artifactId>hudi</artifactId>
         <groupId>io.hops.hudi</groupId>
-        <version>0.10.0.1</version>
+        <version>0.10.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hudi-kafka-connect</artifactId>
     <description>Kafka Connect Sink Connector for Hudi</description>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/hudi-spark-datasource/hudi-spark-common/pom.xml
+++ b/hudi-spark-datasource/hudi-spark-common/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <artifactId>hudi-spark-datasource</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-spark-common_${scala.binary.version}</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-spark-common_${scala.binary.version}</name>
   <packaging>jar</packaging>

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <artifactId>hudi-spark-datasource</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-spark_${scala.binary.version}</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-spark_${scala.binary.version}</name>
   <packaging>jar</packaging>

--- a/hudi-spark-datasource/hudi-spark2/pom.xml
+++ b/hudi-spark-datasource/hudi-spark2/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <artifactId>hudi-spark-datasource</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-spark2_${scala.binary.version}</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-spark2_${scala.binary.version}</name>
   <packaging>jar</packaging>

--- a/hudi-spark-datasource/hudi-spark3/pom.xml
+++ b/hudi-spark-datasource/hudi-spark3/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <artifactId>hudi-spark-datasource</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>hudi-spark3_2.12</artifactId>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
 
   <name>hudi-spark3_2.12</name>
   <packaging>jar</packaging>

--- a/hudi-spark-datasource/pom.xml
+++ b/hudi-spark-datasource/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-sync/hudi-hive-sync/pom.xml
+++ b/hudi-sync/hudi-hive-sync/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/hudi-sync/hudi-sync-common/pom.xml
+++ b/hudi-sync/hudi-sync-common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/hudi-sync/pom.xml
+++ b/hudi-sync/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-timeline-service/pom.xml
+++ b/hudi-timeline-service/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/packaging/hudi-flink-bundle/pom.xml
+++ b/packaging/hudi-flink-bundle/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-hadoop-mr-bundle/pom.xml
+++ b/packaging/hudi-hadoop-mr-bundle/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-integ-test-bundle/pom.xml
+++ b/packaging/hudi-integ-test-bundle/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-kafka-connect-bundle/pom.xml
+++ b/packaging/hudi-kafka-connect-bundle/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>hudi</artifactId>
         <groupId>io.hops.hudi</groupId>
-        <version>0.10.0.1</version>
+        <version>0.10.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-presto-bundle/pom.xml
+++ b/packaging/hudi-presto-bundle/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-timeline-server-bundle/pom.xml
+++ b/packaging/hudi-timeline-server-bundle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>hudi</artifactId>
         <groupId>io.hops.hudi</groupId>
-        <version>0.10.0.1</version>
+        <version>0.10.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <artifactId>hudi</artifactId>
     <groupId>io.hops.hudi</groupId>
-    <version>0.10.0.1</version>
+    <version>0.10.0.3</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <groupId>io.hops.hudi</groupId>
   <artifactId>hudi</artifactId>
   <packaging>pom</packaging>
-  <version>0.10.0.1</version>
+  <version>0.10.0.3</version>
   <description>Apache Hudi brings stream style processing on big data</description>
   <url>https://github.com/apache/hudi</url>
   <name>Hudi</name>


### PR DESCRIPTION
Reverts recent timestamp fix, in favour of https://github.com/logicalclocks/spark/pull/30 I think we have to force merge here for it work. If it doesn't work, I can make another PR