### PR TITLE
[HOPSFS-388] Bump HopsFS and Hive versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,9 +118,9 @@
     <slf4j.version>1.7.36</slf4j.version>
     <joda.version>2.9.9</joda.version>
     <hadoop.groupid>io.hops</hadoop.groupid>
-    <hadoop.version>3.4.3.1-EE-RC0</hadoop.version>
+    <hadoop.version>3.4.3.1-EE-RC4</hadoop.version>
     <hive.groupid>io.hops.hive</hive.groupid>
-    <hive.version>3.0.0.14.5</hive.version>
+    <hive.version>3.0.0.14.6</hive.version>
     <hive.parquet.version>1.13.1</hive.parquet.version>
     <hive.avro.version>1.11.4</hive.avro.version>
     <presto.version>0.273</presto.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-    <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.4</maven-deploy-plugin.version>


### PR DESCRIPTION
Bumps HopsFS to 3.4.3.1-EE-RC4.
Tracked by HOPSFS-388.
